### PR TITLE
🛠️ Issue #1 – Réécriture du README principal + correction de manage.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,62 @@
-# 📋 Spécifications fonctionnelles – Projet Médiathèque Django
-
-Ce document décrit les **fonctionnalités attendues**, les **cas d’usage**, et les **règles métier** du projet de gestion de médiathèque développé avec Django.
-
----
-
-## 🧭 Sommaire
-
-- [🎯 Objectif](#-objectif)
-- [🧩 Fonctionnalités prévues](#-fonctionnalités-prévues)
-- [👥 Cas d’usage](#-cas-dusage)
-- [📌 Contraintes](#-contraintes)
-- [📎 Liens utiles](#-liens-utiles)
-
----
+# 📚 CEF POO Django – Gestion de Médiathèque
 
 ## 🎯 Objectif
 
-Développer une application web permettant la gestion des ressources d’une médiathèque :
-- Livres, CD, DVD
-- Usagers
-- Emprunts et retours
-
-L’application doit être simple, intuitive et adaptée à un usage pédagogique.
+Ce projet pédagogique vise à développer une application web de gestion de médiathèque en utilisant **Django** et les principes de la **programmation orientée objet (POO)**.
 
 ---
 
-## 🧩 Fonctionnalités prévues
+## 🚀 Lancement rapide
 
-### 🔹 Gestion des ressources
-- Ajout, modification, suppression de livres, CD, DVD
-- Classification par type, genre, auteur
+```bash
+cd works
+.\venv\Scripts\activate
+cd mediatheque
+python manage.py runserver 8900
+```
 
-### 🔹 Gestion des usagers
-- Création de comptes usagers
-- Suivi des emprunts et retours
-- Historique des interactions
-
-### 🔹 Emprunts
-- Enregistrement d’un emprunt
-- Détection des retards
-- Retour de ressource
-
-### 🔹 Interfaces
-- Interface d’administration Django
-- Interface utilisateur simplifiée (HTML/CSS)
+Accès local : [http://127.0.0.1:8900](http://127.0.0.1:8900)
 
 ---
 
-## 👥 Cas d’usage
+## 📁 Structure du dépôt
 
-- Un usager emprunte un livre et le retourne
-- Un administrateur ajoute une nouvelle ressource
-- Un usager consulte son historique d’emprunts
-- Un gestionnaire vérifie les ressources disponibles
-
----
-
-## 📌 Contraintes
-
-- Base de données locale (SQLite)
-- Authentification simple
-- Application mono-utilisateur en local
-- Respect des bonnes pratiques Django/POO
+```
+CEF_POO-Django_Gestion-Mediatheque_Test-version/
+├── delivery/           # Livrables
+├── docs/               # Documentation technique et fonctionnelle
+├── works/              # Projet Django et environnement virtuel
+└── README.md           # Présentation générale du projet
+```
 
 ---
 
-## 📎 Liens utiles
+## 📎 Documentation
 
-- [README principal du projet](../../README.md)
-- [README général de la documentation](../README.md)
-- [Spécifications techniques](../technique/README-tech.md)
-- [Suivi du développement](../developpement/README-dev.md)
-- [Architecture du projet](../architecture/README-archi.md)
+La documentation complète est disponible dans le dossier [`/docs`](docs/README.md), organisée par thème :
+- [Spécifications fonctionnelles](docs/fonctionnel/README-fonct.md)
+- [Documentation technique](docs/technique/README-tech.md)
+- [Suivi du développement](docs/developpement/README-dev.md)
+- [Architecture du projet](docs/architecture/README-archi.md)
 
+---
+
+## 🤝 Contribution
+
+Ce projet est réalisé dans un cadre **pédagogique individuel**.  
+Aucune contribution externe n’est demandée.
+
+---
+
+## 📄 Licence
+
+Distribué sous la licence **MIT**.
+
+---
+
+## 👤 Auteur
+
+**PerLucCo**  
+Autoentreprise – Développement Web et Web Mobile  
+📍 Vélizy-Villacoublay, France
 ---

--- a/works/mediatheque/manage.py
+++ b/works/mediatheque/manage.py
@@ -19,4 +19,4 @@ def main():
 
 
 if __name__ == '__main__':
-    mai
+    main()


### PR DESCRIPTION
## 🔧 Corrections apportées dans cette PR

Cette Pull Request complète l’issue [#1 – Préparation de l’environnement](https://github.com/MonLucCo/CEF_POO-Django_Gestion-Mediatheque_Test-version/issues/1) en apportant deux ajustements essentiels :

---

### 📘 1. Réécriture du fichier `/README.md`

- Le contenu précédent correspondait à la spécification fonctionnelle, déplacée dans [`/docs/fonctionnel/README-fonct.md`](docs/fonctionnel/README-fonct.md)
- Le nouveau README présente le projet, les instructions de lancement, la structure du dépôt et les liens vers la documentation

---

### 🐍 2. Correction du fichier `manage.py`

- Correction de la fonction `main()` qui contenait une erreur typographique (`mai` au lieu de `main`)
- Le fichier est désormais conforme à la structure Django standard

---

### 📌 Issue liée

✅ Clôture de l’issue #1  
⏳ L’issue #2 reste ouverte pour :
- Corriger les warnings au lancement du serveur
- Créer l’application principale via `startapp`
- Ajouter l’app dans `INSTALLED_APPS`

---