### PR TITLE
♻️ Correction du dossier media ignoré par Git – renommage en medias

### DIFF
--- a/docs/developpement/issue3/task5/_Frontend-main-courante.md
+++ b/docs/developpement/issue3/task5/_Frontend-main-courante.md
@@ -422,6 +422,15 @@ La résolution de cette difficulté a démontré :
   - les bornes **dynamiques** (ie. année courante) qui doivent être définies dans un formulaire ou une méthode `clean()`.
 - l'importance de garantir l'intégrité métier avec une structure des données toujours cohérente.
 
+### 9.8 Difficulté 8 : nommage des dossiers du projet
+
+Lors de la création de dossiers dans la structure du projet, il est essentiel de vérifier qu’ils ne sont pas exclus par le fichier `.gitignore`.
+Le dossier `media/` est un exemple typique : il est ignoré par défaut, car utilisé pour les fichiers uploadés.
+
+La solution appliquée est d'utiliser le **nom des entités au pluriel pour les dossiers de templates** (medias/, livres/, membres/, etc.).
+
+Cette correction a permis d’explorer l’interface de _refactorisation_ de PyCharm, notamment la _preview_ des impacts et l’exclusion sélective de fichiers sensibles (`.gitignore`, `migrations`).
+
 ---
 
 ## 10. 🔗 Liens utiles

--- a/works/mediatheque/bibliothecaire/templates/bibliothecaire/medias/media_detail.html
+++ b/works/mediatheque/bibliothecaire/templates/bibliothecaire/medias/media_detail.html
@@ -1,0 +1,99 @@
+{% extends 'bibliothecaire/_base.html' %}
+
+{% block title %}Détail du Média{% endblock %}
+
+{% block content %}
+<h2>Détail du média</h2>
+
+<table>
+    <tr>
+        <th>Titre</th>
+        <td>{{ media.name }}</td>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>{{ media.media_type }}</td>
+    </tr>
+    {% if media.annee_edition %}
+        <tr>
+            <th>Année</th>
+            <td>{{ media.annee_edition }}</td>
+        </tr>
+    {%  endif %}
+    <tr>
+        <th>Consultable</th>
+        <td>{{ media.consultable|yesno:"Oui,Non" }}</td>
+    </tr>
+    <tr>
+        <th>Thème</th>
+        <td>{{ media.theme }}</td>
+    </tr>
+    <tr>
+        <th>Disponible</th>
+        {% comment %}
+        <td>{% if media.disponible %}Oui{% else %}Non{% endif %}</td>
+        {% endcomment %}
+        <td>{{ media.disponible|yesno:"Oui,Non" }}</td>
+    </tr>
+
+  {% if media.media_type == "LIVRE" %}
+    <tr>
+        <th>Auteur</th>
+        <td>{{ media.auteur }}</td>
+    </tr>
+    <tr>
+        <th>Nombre de pages</th>
+        {% if media.nb_page %}
+            <td>{{ media.nb_page }}</td>
+        {% else %}
+            <td>non saisie</td>
+        {% endif %}
+    </tr>
+    <tr>
+        <th>Résumé</th>
+        <td>{{ media.resume }}</td>
+    </tr>
+  {% elif media.media_type == "DVD" %}
+    <tr>
+        <th>Réalisateur</th>
+        <td>{{ media.realisateur }}</td>
+    </tr>
+    <tr>
+        <th>Durée</th>
+        {% if media.duree %}
+            <td>{{ media.duree }} minute(s)</td>
+        {% else %}
+            <td>non saisie</td>
+        {% endif %}
+    </tr>
+    <tr><th>Histoire</th><td>{{ media.histoire }}</td></tr>
+  {% elif media.media_type == "CD" %}
+    <tr>
+        <th>Artiste</th>
+        <td>{{ media.artiste }}</td>
+    </tr>
+    <tr>
+        <th>Nombre de pistes</th>
+        <td>{{ media.nb_piste }}</td>
+    </tr>
+    <tr>
+        <th>Durée d'écoute</th>
+        {%  if media.duree_ecoute %}
+            <td>{{ media.duree_ecoute }} minute(s)</td>
+        {%  else %}
+            <td>non saisie</td>
+        {% endif %}
+    </tr>
+  {% endif %}
+</table>
+
+<div style="margin-top: 20px;">
+{% comment %}
+    <a href="{% url 'bibliothecaire:media_update' media.pk %}">Modifier</a> |
+    <a href="{% url 'bibliothecaire:media_delete' media.pk %}">Supprimer</a> |
+{% endcomment %}
+    <a href="{% url 'bibliothecaire:media_list' %}">Retour à la liste</a>
+</div>
+
+
+{% endblock %}

--- a/works/mediatheque/bibliothecaire/templates/bibliothecaire/medias/media_list.html
+++ b/works/mediatheque/bibliothecaire/templates/bibliothecaire/medias/media_list.html
@@ -1,0 +1,18 @@
+{% extends 'bibliothecaire/_base.html' %}
+
+{% block title %}Catalogue des Médias{% endblock %}
+
+{% block content %}
+<h2>Liste des médias</h2>
+<ul>
+  {% for media in medias %}
+    <li>
+      <a href="{% url 'bibliothecaire:media_detail' media.pk %}">
+        {{ media.name }} ({{ media.media_type }}) {% if media.disponible %}- [disponible]{% endif %}
+      </a>
+    </li>
+  {% empty %}
+    <li>Aucun média disponible.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/works/mediatheque/bibliothecaire/tests_blocs/test_urls.py
+++ b/works/mediatheque/bibliothecaire/tests_blocs/test_urls.py
@@ -11,7 +11,7 @@ class NavigationTests(TestCase):
     def test_nav_02_media_list_accessible(self):
         response = self.client.get(reverse('bibliothecaire:media_list'))
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'bibliothecaire/media/media_list.html')
+        self.assertTemplateUsed(response, 'bibliothecaire/medias/media_list.html')
 
     def test_nav_03_media_detail_accessible(self):
         # Préparer un media
@@ -19,7 +19,7 @@ class NavigationTests(TestCase):
         media = Media.objects.create(name="Test", media_type="LIVRE", theme="Test")
         response = self.client.get(reverse('bibliothecaire:media_detail', args=[media.id]))
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'bibliothecaire/media/media_detail.html')
+        self.assertTemplateUsed(response, 'bibliothecaire/medias/media_detail.html')
 
     def test_nav_04_media_detail_404(self):
         response = self.client.get(reverse('bibliothecaire:media_detail', args=[999]))

--- a/works/mediatheque/bibliothecaire/urls.py
+++ b/works/mediatheque/bibliothecaire/urls.py
@@ -9,11 +9,11 @@ urlpatterns = [
     path('accueil/', views.AccueilBibliothecaireView.as_view(), name='accueil'),
 
     # Media (Livre, Dvd, Cd)
-    path('media/', views.MediaListView.as_view(), name='media_list'),
-    path('media/<int:pk>/', views.MediaDetailView.as_view(), name='media_detail'),
-#    path('media/ajouter/', views.MediaCreateView.as_view(), name='media_create'),
-#    path('media/<int:pk>/modifier/', views.MediaUpdateView.as_view(), name='media_update'),
-#    path('media/<int:pk>/supprimer/', views.MediaDeleteView.as_view(), name='media_delete'),
+    path('medias/', views.MediaListView.as_view(), name='media_list'),
+    path('medias/<int:pk>/', views.MediaDetailView.as_view(), name='media_detail'),
+#    path('medias/ajouter/', views.MediaCreateView.as_view(), name='media_create'),
+#    path('medias/<int:pk>/modifier/', views.MediaUpdateView.as_view(), name='media_update'),
+#    path('medias/<int:pk>/supprimer/', views.MediaDeleteView.as_view(), name='media_delete'),
 
     # Emprunts
  #   path('emprunts/', views.EmpruntListView.as_view(), name='emprunt_list'),
@@ -28,7 +28,7 @@ urlpatterns = [
  #   path('membres/<int:pk>/supprimer/', views.MembreDeleteView.as_view(), name='membre_delete'),
 
     # Fonctionnalités souhaitables (optionnelles)
- #   path('media/type/<str:type>/', views.MediaFilteredListView.as_view(), name='media_filtered'),
+ #   path('medias/type/<str:type>/', views.MediaFilteredListView.as_view(), name='media_filtered'),
  #   path('emprunts/statut/<int:statut>/', views.EmpruntFilteredListView.as_view(), name='emprunt_filtered'),
  #   path('membres/<int:pk>/historique/', views.MembreHistoriqueView.as_view(), name='membre_historique'),
  #    path('jeux/', views.JeuListView.as_view(), name='jeu_list'),

--- a/works/mediatheque/bibliothecaire/views.py
+++ b/works/mediatheque/bibliothecaire/views.py
@@ -11,11 +11,11 @@ class AccueilBibliothecaireView(TemplateView):
 class MediaListView(ListView):
     model = Media
     context_object_name = 'medias'
-    template_name = 'bibliothecaire/media/media_list.html'
+    template_name = 'bibliothecaire/medias/media_list.html'
 class MediaDetailView(DetailView):
     model = Media
     context_object_name = 'media'
-    template_name = 'bibliothecaire/media/media_detail.html'
+    template_name = 'bibliothecaire/medias/media_detail.html'
 
     def get_object(self, queryset=None):
         obj = super(MediaDetailView, self).get_object(queryset)


### PR DESCRIPTION
### Description

Cette PR corrige un conflit entre la structure des templates et le fichier `.gitignore`, qui excluait le dossier `media/`. Le dossier est renommé en `medias/`, conformément à la convention de nommage au pluriel des entités (livres/, membres/, etc.).

### Modifications incluses

1. Renommage du dossier `media/` → `medias/`
1. Mise à jour des chemins dans les vues, les routes et les tests T-NAV-02/03
1. ✅ Tous les tests unitaires sont passés avec succès

Cette correction structurelle garantit que le projet est clonable et fonctionnel depuis GitHub à ce stade du développement.